### PR TITLE
Cannot read properties of null (reading 'length')

### DIFF
--- a/src/methods/favorite.js
+++ b/src/methods/favorite.js
@@ -4,6 +4,6 @@ export default {
     localStorage.setItem('favoriteList', favoriteStr);
   },
   getFavorite() {
-    return JSON.parse(localStorage.getItem('favoriteList'));
+    return JSON.parse(localStorage.getItem('favoriteList') || '[]');
   },
 };


### PR DESCRIPTION
![image](https://github.com/7rong/i-sea/assets/4183364/cf5fcf67-e331-4fa0-98bd-e8298ea14f29)

由於從 localStorage 取出來是 `null` -> 所以經過 `JSON.parse()` 還是 `null` 所以沒有轉成陣列。

再來我有在面試中提到的 `try-catch` 的寫法，由於 `JSON.parse` 會正常解析 `null` 固不會發生 `exception`，只有無法正常解析的狀況才會發生 `exception`，所以 `try-catch` 寫法會是用來防呆無法正常解析的情境。